### PR TITLE
Added missing variable and quoted replacements

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -16,6 +16,9 @@ VAR_APP_NAME='Django Reusable App Template'
 # The package name, which would be added to INSTALLED_APPS
 VAR_PACKAGE_NAME='reusable_app_template'
 
+# Example URL path the app should be loaded at
+VAR_URL_HOOK='reusable_app_template'
+
 # The package name as defined in setup.py - this is also what you would search
 # for on pypi.python.org. You should search pypi.python.org first and make sure
 # that your package name is not taken already.
@@ -39,15 +42,16 @@ VAR_YEAR=`date +'%Y'`
 rm -rf .git
 rm README.rst
 CMD=(find . -type f \( ! -iname '*.pyc' ! -iname 'init.sh' \) -print0)
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_YEAR#${VAR_YEAR}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_FULL_NAME#${VAR_FULL_NAME}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_AUTHOR_EMAIL#${VAR_AUTHOR_EMAIL}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_APP_NAME#${VAR_APP_NAME}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_PACKAGE_NAME#${VAR_PACKAGE_NAME}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_PYPI_NAME#${VAR_PYPI_NAME}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_DESCRIPTION#${VAR_DESCRIPTION}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_GITHUB_REPO#${VAR_GITHUB_REPO}#g
-"${CMD[@]}" | xargs -0 perl -pi -e s#VAR_KEYWORDS#${VAR_KEYWORDS}#g
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_YEAR#${VAR_YEAR}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_FULL_NAME#${VAR_FULL_NAME}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_AUTHOR_EMAIL#${VAR_AUTHOR_EMAIL}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_APP_NAME#${VAR_APP_NAME}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_PACKAGE_NAME#${VAR_PACKAGE_NAME}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_PYPI_NAME#${VAR_PYPI_NAME}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_DESCRIPTION#${VAR_DESCRIPTION}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_GITHUB_REPO#${VAR_GITHUB_REPO}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_KEYWORDS#${VAR_KEYWORDS}#g"
+"${CMD[@]}" | xargs -0 perl -pi -e "s#VAR_URL_HOOK#${VAR_URL_HOOK}#g"
 mv package_name $VAR_PACKAGE_NAME
 rm init.sh
 mv NEW_README.rst README.rst


### PR DESCRIPTION
Saw `VAR_URL_HOOK` in `NEW_README.rst` and added it as an option.

The replacements weren't working for my app new app because the replacements weren't properly quoted. Not sure what part of my input values were wrong, but there shouldn't be any big issues with using double quotes.
