### PR TITLE
Add encoding in setyp.py for python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """
 Python setup file for the VAR_PACKAGE_NAME app.
 


### PR DESCRIPTION
Since my name got an umlaut in it, the file broke on first run with python 2.7 since it didn't know what encoding the file was in all of a sudden. Assuming UTF-8 should be a safe assumption these days.
